### PR TITLE
spec: propose specification /validators/[deviceId]/response

### DIFF
--- a/specifications/validators/[deviceId]/response/response.example.json
+++ b/specifications/validators/[deviceId]/response/response.example.json
@@ -1,7 +1,7 @@
 {
   "traceId": "48b12d1f-6b96-4f70-94f9-f785cef96812",
   "eventTimestamp": "2023-09-01T23:45:52Z",
-  "inspectionResult": {
+  "result": {
     "validity": "VALID"
   }
 }

--- a/specifications/validators/[deviceId]/response/response.example.json
+++ b/specifications/validators/[deviceId]/response/response.example.json
@@ -1,0 +1,7 @@
+{
+  "traceId": "48b12d1f-6b96-4f70-94f9-f785cef96812",
+  "eventTimestamp": "2023-09-01T23:45:52Z",
+  "inspectionResult": {
+    "validity": "VALID"
+  }
+}

--- a/specifications/validators/[deviceId]/response/response.fail.json
+++ b/specifications/validators/[deviceId]/response/response.fail.json
@@ -1,0 +1,9 @@
+{
+  "traceId": "48b12d1f-6b96-4f70-94f9-f785cef96812",
+  "eventTimestamp": "2023-09-01T23:45:52Z",
+  "inspectionResult": {
+    "title": "Godkjent",
+    "message": "Validert 22/04/2020 13:19 Enkeltbillett 1 Voksen",
+    "validity": "UGYLDIG"
+  }
+}

--- a/specifications/validators/[deviceId]/response/response.fail.json
+++ b/specifications/validators/[deviceId]/response/response.fail.json
@@ -1,7 +1,7 @@
 {
   "traceId": "48b12d1f-6b96-4f70-94f9-f785cef96812",
   "eventTimestamp": "2023-09-01T23:45:52Z",
-  "inspectionResult": {
+  "result": {
     "title": "Godkjent",
     "message": "Validert 22/04/2020 13:19 Enkeltbillett 1 Voksen",
     "validity": "UGYLDIG"

--- a/specifications/validators/[deviceId]/response/response.fail.json
+++ b/specifications/validators/[deviceId]/response/response.fail.json
@@ -3,7 +3,7 @@
   "eventTimestamp": "2023-09-01T23:45:52Z",
   "result": {
     "title": "Godkjent",
-    "message": "Validert 22/04/2020 13:19 Enkeltbillett 1 Voksen",
+    "description": "Validert 22/04/2020 13:19 Enkeltbillett 1 Voksen",
     "validity": "UGYLDIG"
   }
 }

--- a/specifications/validators/[deviceId]/response/response.md
+++ b/specifications/validators/[deviceId]/response/response.md
@@ -24,7 +24,7 @@ Device should optionally recieve title and message if supported by the device.
 {
   "traceId": "48b12d1f-6b96-4f70-94f9-f785cef96812",
   "eventTimestamp": "2023-09-01T23:45:52Z",
-  "inspectionResult": {
+  "result": {
     "title": "Godkjent",
     "message": "Validert 22/04/2020 13:19 Enkeltbillett 1 Voksen ",
     "validity": "VALID"

--- a/specifications/validators/[deviceId]/response/response.md
+++ b/specifications/validators/[deviceId]/response/response.md
@@ -10,7 +10,8 @@ fail and error. In the current specification the response method is limited to a
 variant type/enum, and it's up to the device to handle the proper response in
 form of icon, color and sound.
 
-Device should optionally recieve title and message if supported by the device.
+Device should optionally recieve title and description if supported by the
+device.
 
 - Topic: `validators/[deviceId]/response`
 - Direction: Consume (Outbound from client)
@@ -26,7 +27,7 @@ Device should optionally recieve title and message if supported by the device.
   "eventTimestamp": "2023-09-01T23:45:52Z",
   "result": {
     "title": "Godkjent",
-    "message": "Validert 22/04/2020 13:19 Enkeltbillett 1 Voksen ",
+    "description": "Validert 22/04/2020 13:19 Enkeltbillett 1 Voksen ",
     "validity": "VALID"
   }
 }

--- a/specifications/validators/[deviceId]/response/response.md
+++ b/specifications/validators/[deviceId]/response/response.md
@@ -1,0 +1,33 @@
+---
+version: 1.0.0
+lastUpdated: 2023-06-09
+---
+
+# Specification: Validation Response
+
+Response sent after finished validation on client. Response can be both success,
+fail and error. In the current specification the response method is limited to a
+variant type/enum, and it's up to the device to handle the proper response in
+form of icon, color and sound.
+
+Device should optionally recieve title and message if supported by the device.
+
+- Topic: `validators/[deviceId]/response`
+- Direction: Consume (Outbound from client)
+- JSON Schema: [response.schema.json](./response.schema.json)
+- MQTT QoS: 1 (at least once)
+- Trigger: After validation result on client
+
+## Examples
+
+```json
+{
+  "traceId": "48b12d1f-6b96-4f70-94f9-f785cef96812",
+  "eventTimestamp": "2023-09-01T23:45:52Z",
+  "inspectionResult": {
+    "title": "Godkjent",
+    "message": "Validert 22/04/2020 13:19 Enkeltbillett 1 Voksen ",
+    "validity": "VALID"
+  }
+}
+```

--- a/specifications/validators/[deviceId]/response/response.schema.json
+++ b/specifications/validators/[deviceId]/response/response.schema.json
@@ -17,26 +17,26 @@
       "format": "date-time",
       "description": "Timestamp for when the validation happened. UTC in RFC3339 format."
     },
-    "inspectionResult": {
-      "$id": "#/properties/inspectionResult",
+    "result": {
+      "$id": "#/properties/result",
       "type": "object",
-      "description": "Information about actual inspection result.",
+      "description": "Information about actual for the validation result.",
       "required": ["validity"],
       "properties": {
         "validity": {
-          "$id": "#/properties/inspectionResult/validity",
+          "$id": "#/properties/result/validity",
           "type": "string",
           "pattern": "^(VALID|INVALID|ERROR|WARNING)$",
           "description": "Enum of validity. Either VALID, INVALID, WARNING or ERROR"
         },
         "title": {
-          "$id": "#/properties/inspectionResult/title",
+          "$id": "#/properties/result/title",
           "type": "string",
           "maxLength": 100,
           "description": "Optional Title (Large text on top). Limited to 100 characters."
         },
         "message": {
-          "$id": "#/properties/inspectionResult/message",
+          "$id": "#/properties/result/message",
           "type": "string",
           "maxLength": 150,
           "description": "Optional message (smaller text under title). Limited to 150 characters."
@@ -44,5 +44,5 @@
       }
     }
   },
-  "required": ["traceId", "eventTimestamp", "inspectionResult"]
+  "required": ["traceId", "eventTimestamp", "result"]
 }

--- a/specifications/validators/[deviceId]/response/response.schema.json
+++ b/specifications/validators/[deviceId]/response/response.schema.json
@@ -35,11 +35,11 @@
           "maxLength": 100,
           "description": "Optional Title (Large text on top). Limited to 100 characters."
         },
-        "message": {
-          "$id": "#/properties/result/message",
+        "description": {
+          "$id": "#/properties/result/description",
           "type": "string",
           "maxLength": 150,
-          "description": "Optional message (smaller text under title). Limited to 150 characters."
+          "description": "Optional description (smaller text under title). Limited to 150 characters."
         }
       }
     }

--- a/specifications/validators/[deviceId]/response/response.schema.json
+++ b/specifications/validators/[deviceId]/response/response.schema.json
@@ -26,8 +26,8 @@
         "validity": {
           "$id": "#/properties/inspectionResult/validity",
           "type": "string",
-          "pattern": "^(VALID|INVALID|ERROR)$",
-          "description": "Enum of validity. Either VALID, INVALID or ERROR"
+          "pattern": "^(VALID|INVALID|ERROR|WARNING)$",
+          "description": "Enum of validity. Either VALID, INVALID, WARNING or ERROR"
         },
         "title": {
           "$id": "#/properties/inspectionResult/title",

--- a/specifications/validators/[deviceId]/response/response.schema.json
+++ b/specifications/validators/[deviceId]/response/response.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/mrfylke/mtbuss-mqtt-validator/specifications/validators/[deviceId]/response.schema.json",
+  "title": "Validation Response",
+  "type": "object",
+  "description": "Response sent to devices after inspection result has been found.",
+  "properties": {
+    "traceId": {
+      "$id": "#/properties/traceId",
+      "type": "string",
+      "format": "uuid",
+      "description": "An unique message identifier - UUID v4"
+    },
+    "eventTimestamp": {
+      "$id": "#/properties/eventTimestamp",
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp for when the validation happened. UTC in RFC3339 format."
+    },
+    "inspectionResult": {
+      "$id": "#/properties/inspectionResult",
+      "type": "object",
+      "description": "Information about actual inspection result.",
+      "required": ["validity"],
+      "properties": {
+        "validity": {
+          "$id": "#/properties/inspectionResult/validity",
+          "type": "string",
+          "pattern": "^(VALID|INVALID|ERROR)$",
+          "description": "Enum of validity. Either VALID, INVALID or ERROR"
+        },
+        "title": {
+          "$id": "#/properties/inspectionResult/title",
+          "type": "string",
+          "maxLength": 100,
+          "description": "Optional Title (Large text on top). Limited to 100 characters."
+        },
+        "message": {
+          "$id": "#/properties/inspectionResult/message",
+          "type": "string",
+          "maxLength": 150,
+          "description": "Optional message (smaller text under title). Limited to 150 characters."
+        }
+      }
+    }
+  },
+  "required": ["traceId", "eventTimestamp", "inspectionResult"]
+}

--- a/tools/types.ts
+++ b/tools/types.ts
@@ -1,4 +1,4 @@
 
-export type TopicName = 'sensors/location' | 'validators/barcode';
-export const availableTopics = ["sensors/location","validators/barcode"] as readonly TopicName[];
-export const topicSet = {"sensors/location":"sensors/location/location.schema.json","validators/barcode":"validators/barcode/barcode.schema.json"} satisfies Record<TopicName, string>;
+export type TopicName = 'sensors/location' | 'validators/barcode' | 'validators/[deviceId]/response';
+export const availableTopics = ["sensors/location","validators/barcode","validators/[deviceId]/response"] as readonly TopicName[];
+export const topicSet = {"sensors/location":"sensors/location/location.schema.json","validators/barcode":"validators/barcode/barcode.schema.json","validators/[deviceId]/response":"validators/[deviceId]/response/response.schema.json"} satisfies Record<TopicName, string>;


### PR DESCRIPTION
# Proposal: Validation Response

Specification for messages passed after inspection result is found. Communicate the validation response from client to devices.

## Context and known limitations

Currently only supports enum based success/fail scenario and no customizing sound, buzz, color etc. That has to be handled on the device in the initial version.

Related #4 #3 

---

## Checklist

- [x] Includes documentation file with description, topics and examples.
- [x] Includes JSON Schema
- [x] Includes passing and failing tests.

## Confirmed and verified by parties

- [ ] MT Buss
- [ ] Consat
- [ ] Fara
