### PR TITLE
docs: updates missing fields from example

### DIFF
--- a/specifications/device/[deviceId]/diagnostics/diagnostics.md
+++ b/specifications/device/[deviceId]/diagnostics/diagnostics.md
@@ -37,6 +37,9 @@ specific devices.
 
 ```json
 {
+  "traceId": "543070fe-ef32-11ed-a05b-0242ac120003",
+  "deviceId": "flv202400004",
+  "eventTimestamp": "2023-04-22T10:28:37.337Z",
   "manufacturer": "Acme",
   "model": "NFC2000b",
   "serial": "F0A222100004",
@@ -52,6 +55,9 @@ specific devices.
 
 ```json
 {
+  "traceId": "543070fe-ef32-11ed-a05b-0242ac120003",
+  "deviceId": "flv202400004",
+  "eventTimestamp": "2023-04-22T10:28:37.337Z",
   "manufacturer": "Acme",
   "model": "LocOmotive2",
   "serial": "LL0A222100004",

--- a/specifications/device/diagnostics/diagnostics.md
+++ b/specifications/device/diagnostics/diagnostics.md
@@ -32,6 +32,9 @@ a response to a diagnostics check. See related topics in next section.
 
 ```json
 {
+  "traceId": "543070fe-ef32-11ed-a05b-0242ac120003",
+  "deviceId": "flv202400004",
+  "eventTimestamp": "2023-04-22T10:28:37.337Z",
   "manufacturer": "Acme",
   "model": "NFC2000b",
   "serial": "F0A222100004",
@@ -47,6 +50,9 @@ a response to a diagnostics check. See related topics in next section.
 
 ```json
 {
+  "traceId": "543070fe-ef32-11ed-a05b-0242ac120003",
+  "deviceId": "flv202400004",
+  "eventTimestamp": "2023-04-22T10:28:37.337Z",
   "manufacturer": "Acme",
   "model": "LocOmotive2",
   "serial": "LL0A222100004",


### PR DESCRIPTION
Fixes missing fields from example. This was correct in the schema definitions (which is the truth), but examples didn't reflect correct schema definitions